### PR TITLE
Revert header to minimal design with theme toggle only

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,10 +13,6 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
                 <button 
                     id="themeToggle" 
                     class="theme-toggle" 

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -66,39 +66,19 @@ body {
 
 /* Header */
 header {
-    padding: 1.5rem 2rem;
+    padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     flex-shrink: 0;
 }
 
 .header-content {
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
     align-items: center;
     max-width: 1200px;
     margin: 0 auto;
 }
 
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -771,10 +751,6 @@ details[open] .suggested-header::before {
     
     header {
         padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
     }
     
     .chat-messages {


### PR DESCRIPTION
Fixes #2

Reverts the header to a minimal design as requested:
- Removes "Course Materials Assistant" title
- Removes subtitle about asking questions
- Removes horizontal border line below header
- Keeps theme toggle functionality intact
- Adjusts header styling and padding

Generated with [Claude Code](https://claude.ai/code)